### PR TITLE
Track export options

### DIFF
--- a/Configuration/export_options.plist
+++ b/Configuration/export_options.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>compileBitcode</key>
+	<false/>
+	<key>destination</key>
+	<string>export</string>
+	<key>method</key>
+	<string>development</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>DT2C2FZ7U2</string>
+	<key>thinning</key>
+	<string>&lt;none&gt;</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios</key>
+		<string>Backyard-Birds OneMoreThingConf iOS Development</string>
+		<key>com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios.Widgets</key>
+		<string>Backyard-Birds OneMoreThingConf iOS Widgets</string>
+		<key>com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.watch</key>
+		<string>Backyard-Birds OneMoreThingConf watchOS Developmen</string>
+		<key>com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.watch.Widgets</key>
+		<string>Backyard-Birds OneMoreThingConf watchOS Widgets</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Let's track export options directly in the repo. Then the initial workflow setup doesn't need to involve copying an unwieldy string. 

Would look like this

```
    - script@1:
        inputs:
        - script_file_path:
        - content: |-
            #!/usr/bin/env bash
            envman add --key EXPORT_OPTIONS --value "$(cat Configuration/export_options.plist)"
        title: Make export options available
    - xcode-archive@5:
        inputs:
        - project_path: "$BITRISE_PROJECT_PATH"
        - scheme: "$BITRISE_SCHEME"
        - distribution_method: "$BITRISE_DISTRIBUTION_METHOD"
        - export_options_plist_content: "$EXPORT_OPTIONS"
        - cache_level: none
```