### PR TITLE
Adds automated tests

### DIFF
--- a/Backyard Birds.xcodeproj/project.pbxproj
+++ b/Backyard Birds.xcodeproj/project.pbxproj
@@ -17,6 +17,11 @@
 		8B083A4D2A1D47DC0098F3BB /* BirdFoodProductIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A467362A154AD80010173E /* BirdFoodProductIcon.swift */; };
 		8B083A4E2A1D53A50098F3BB /* BirdFoodPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A467122A153D430010173E /* BirdFoodPickerSheet.swift */; };
 		8B083A4F2A1D53BA0098F3BB /* BirdFoodQuantityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A4672E2A153F3F0010173E /* BirdFoodQuantityBadge.swift */; };
+		AF57142E2C0D19AB001E9B8C /* BackyardsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF57142D2C0D19AB001E9B8C /* BackyardsUITests.swift */; };
+		AF5714302C0D19AB001E9B8C /* BirdsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF57142F2C0D19AB001E9B8C /* BirdsUITests.swift */; };
+		AF5714372C0D59D5001E9B8C /* PlantsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5714362C0D59D5001E9B8C /* PlantsUITests.swift */; };
+		AF5714452C0D5C36001E9B8C /* BackyardBirdsUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF57143E2C0D5AEA001E9B8C /* BackyardBirdsUnitTests.swift */; };
+		AF5714472C0D5C79001E9B8C /* FailingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5714462C0D5C79001E9B8C /* FailingUITests.swift */; };
 		E018B6B82A180811007EC687 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E018B6B72A180811007EC687 /* InfoPlist.xcstrings */; };
 		E018B6BF2A180E64007EC687 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E018B6BD2A180E63007EC687 /* Localizable.xcstrings */; };
 		E018B6C02A180E64007EC687 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E018B6BE2A180E64007EC687 /* InfoPlist.xcstrings */; };
@@ -103,6 +108,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		AF5714312C0D19AB001E9B8C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E0A466BB2A153A0E0010173E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E0A466C22A153A0E0010173E;
+			remoteInfo = "Backyard Birds";
+		};
+		AF5714402C0D5AEA001E9B8C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E0A466BB2A153A0E0010173E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E0A466C22A153A0E0010173E;
+			remoteInfo = "Backyard Birds";
+		};
 		E0766CC22A15BF5100DD69B6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E0A466BB2A153A0E0010173E /* Project object */;
@@ -205,6 +224,16 @@
 		33B5D3E92A1EDC5B00436727 /* StoreMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMetrics.swift; sourceTree = "<group>"; };
 		7CF145E82B654006AC6F97C0 /* SampleCode.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = SampleCode.xcconfig; path = Configuration/SampleCode.xcconfig; sourceTree = "<group>"; };
 		92D5096013A7C944A726F872 /* LICENSE.txt */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		AF57142B2C0D19AB001E9B8C /* Backyard BirdsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Backyard BirdsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AF57142D2C0D19AB001E9B8C /* BackyardsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackyardsUITests.swift; sourceTree = "<group>"; };
+		AF57142F2C0D19AB001E9B8C /* BirdsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirdsUITests.swift; sourceTree = "<group>"; };
+		AF5714362C0D59D5001E9B8C /* PlantsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlantsUITests.swift; sourceTree = "<group>"; };
+		AF57143C2C0D5AEA001E9B8C /* BackyardBirdsUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BackyardBirdsUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AF57143E2C0D5AEA001E9B8C /* BackyardBirdsUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackyardBirdsUnitTests.swift; sourceTree = "<group>"; };
+		AF5714462C0D5C79001E9B8C /* FailingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailingUITests.swift; sourceTree = "<group>"; };
+		AF5714482C0D5FC3001E9B8C /* UITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = SOURCE_ROOT; };
+		AF5714492C0D5FF4001E9B8C /* FailingTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FailingTests.xctestplan; sourceTree = "<group>"; };
+		AF57144A2C0D6018001E9B8C /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		E0163BA82A17335800D77227 /* Backyard-Birds-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Backyard-Birds-Info.plist"; sourceTree = "<group>"; };
 		E018B6B72A180811007EC687 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		E018B6B92A180E47007EC687 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
@@ -284,6 +313,20 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		AF5714282C0D19AB001E9B8C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AF5714392C0D5AEA001E9B8C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E0A466C02A153A0E0010173E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -328,6 +371,25 @@
 			path = .;
 			sourceTree = "<group>";
 		};
+		AF57142C2C0D19AB001E9B8C /* Backyard BirdsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				AF57142D2C0D19AB001E9B8C /* BackyardsUITests.swift */,
+				AF57142F2C0D19AB001E9B8C /* BirdsUITests.swift */,
+				AF5714362C0D59D5001E9B8C /* PlantsUITests.swift */,
+				AF5714462C0D5C79001E9B8C /* FailingUITests.swift */,
+			);
+			path = "Backyard BirdsUITests";
+			sourceTree = "<group>";
+		};
+		AF57143D2C0D5AEA001E9B8C /* BackyardBirdsUnitTests */ = {
+			isa = PBXGroup;
+			children = (
+				AF57143E2C0D5AEA001E9B8C /* BackyardBirdsUnitTests.swift */,
+			);
+			path = BackyardBirdsUnitTests;
+			sourceTree = "<group>";
+		};
 		E081339B2A15714A00151E9A /* Misc */ = {
 			isa = PBXGroup;
 			children = (
@@ -339,6 +401,7 @@
 		E0A466BA2A153A0E0010173E = {
 			isa = PBXGroup;
 			children = (
+				AF57144A2C0D6018001E9B8C /* UnitTests.xctestplan */,
 				E0A466F12A153A2B0010173E /* README.md */,
 				E0163BA82A17335800D77227 /* Backyard-Birds-Info.plist */,
 				E0A466F22A153A4A0010173E /* Multiplatform */,
@@ -348,9 +411,13 @@
 				E0A467682A156D920010173E /* BackyardBirdsUI */,
 				E08133992A15712700151E9A /* LayeredArtworkLibrary */,
 				E081339B2A15714A00151E9A /* Misc */,
+				AF57142C2C0D19AB001E9B8C /* Backyard BirdsUITests */,
+				AF57143D2C0D5AEA001E9B8C /* BackyardBirdsUnitTests */,
 				E0A4674C2A154EB00010173E /* Frameworks */,
 				E0A466C42A153A0E0010173E /* Products */,
 				ED4C08B27E7DC165D4776BCE /* Configuration */,
+				AF5714482C0D5FC3001E9B8C /* UITests.xctestplan */,
+				AF5714492C0D5FF4001E9B8C /* FailingTests.xctestplan */,
 				ACCC3835AA4939F54BA1ACC1 /* LICENSE */,
 			);
 			sourceTree = "<group>";
@@ -361,6 +428,8 @@
 				E0A466C32A153A0E0010173E /* Backyard Birds.app */,
 				E0A4674B2A154EAF0010173E /* Widgets.appex */,
 				E0F7709E2A15AA900042CE8B /* Backyard Birds.app */,
+				AF57142B2C0D19AB001E9B8C /* Backyard BirdsUITests.xctest */,
+				AF57143C2C0D5AEA001E9B8C /* BackyardBirdsUnitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -544,6 +613,42 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		AF57142A2C0D19AB001E9B8C /* Backyard BirdsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AF5714332C0D19AB001E9B8C /* Build configuration list for PBXNativeTarget "Backyard BirdsUITests" */;
+			buildPhases = (
+				AF5714272C0D19AB001E9B8C /* Sources */,
+				AF5714282C0D19AB001E9B8C /* Frameworks */,
+				AF5714292C0D19AB001E9B8C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AF5714322C0D19AB001E9B8C /* PBXTargetDependency */,
+			);
+			name = "Backyard BirdsUITests";
+			productName = "Backyard BirdsUITests";
+			productReference = AF57142B2C0D19AB001E9B8C /* Backyard BirdsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		AF57143B2C0D5AEA001E9B8C /* BackyardBirdsUnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AF5714422C0D5AEA001E9B8C /* Build configuration list for PBXNativeTarget "BackyardBirdsUnitTests" */;
+			buildPhases = (
+				AF5714382C0D5AEA001E9B8C /* Sources */,
+				AF5714392C0D5AEA001E9B8C /* Frameworks */,
+				AF57143A2C0D5AEA001E9B8C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AF5714412C0D5AEA001E9B8C /* PBXTargetDependency */,
+			);
+			name = BackyardBirdsUnitTests;
+			productName = BackyardBirdsUnitTests;
+			productReference = AF57143C2C0D5AEA001E9B8C /* BackyardBirdsUnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		E0A466C22A153A0E0010173E /* Backyard Birds */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E0A466E82A153A100010173E /* Build configuration list for PBXNativeTarget "Backyard Birds" */;
@@ -626,10 +731,19 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1500;
+				DefaultBuildSystemTypeForWorkspace = Latest;
+				LastSwiftUpdateCheck = 1540;
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = Apple;
 				TargetAttributes = {
+					AF57142A2C0D19AB001E9B8C = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = E0A466C22A153A0E0010173E;
+					};
+					AF57143B2C0D5AEA001E9B8C = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = E0A466C22A153A0E0010173E;
+					};
 					E0A466C22A153A0E0010173E = {
 						CreatedOnToolsVersion = 15.0;
 					};
@@ -665,11 +779,27 @@
 				E0A466C22A153A0E0010173E /* Backyard Birds */,
 				E0F7709D2A15AA900042CE8B /* Backyard Birds (Watch) */,
 				E0A4674A2A154EAF0010173E /* Widgets */,
+				AF57142A2C0D19AB001E9B8C /* Backyard BirdsUITests */,
+				AF57143B2C0D5AEA001E9B8C /* BackyardBirdsUnitTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		AF5714292C0D19AB001E9B8C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AF57143A2C0D5AEA001E9B8C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E0A466C12A153A0E0010173E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -703,6 +833,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		AF5714272C0D19AB001E9B8C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF5714302C0D19AB001E9B8C /* BirdsUITests.swift in Sources */,
+				AF5714372C0D59D5001E9B8C /* PlantsUITests.swift in Sources */,
+				AF5714472C0D5C79001E9B8C /* FailingUITests.swift in Sources */,
+				AF57142E2C0D19AB001E9B8C /* BackyardsUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AF5714382C0D5AEA001E9B8C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF5714452C0D5C36001E9B8C /* BackyardBirdsUnitTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E0A466BF2A153A0E0010173E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -788,6 +937,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		AF5714322C0D19AB001E9B8C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E0A466C22A153A0E0010173E /* Backyard Birds */;
+			targetProxy = AF5714312C0D19AB001E9B8C /* PBXContainerItemProxy */;
+		};
+		AF5714412C0D5AEA001E9B8C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E0A466C22A153A0E0010173E /* Backyard Birds */;
+			targetProxy = AF5714402C0D5AEA001E9B8C /* PBXContainerItemProxy */;
+		};
 		E0766CC32A15BF5100DD69B6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E0A4674A2A154EAF0010173E /* Widgets */;
@@ -807,6 +966,86 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		AF5714342C0D19AB001E9B8C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bitrise.Backyard-BirdsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Backyard Birds";
+			};
+			name = Debug;
+		};
+		AF5714352C0D19AB001E9B8C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bitrise.Backyard-BirdsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Backyard Birds";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AF5714432C0D5AEA001E9B8C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.BackyardBirdsUnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Backyard Birds.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Backyard Birds";
+			};
+			name = Debug;
+		};
+		AF5714442C0D5AEA001E9B8C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72SA8V3WYL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.BackyardBirdsUnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Backyard Birds.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Backyard Birds";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		E0A466E62A153A100010173E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7CF145E82B654006AC6F97C0 /* SampleCode.xcconfig */;
@@ -1225,6 +1464,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		AF5714332C0D19AB001E9B8C /* Build configuration list for PBXNativeTarget "Backyard BirdsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AF5714342C0D19AB001E9B8C /* Debug */,
+				AF5714352C0D19AB001E9B8C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AF5714422C0D5AEA001E9B8C /* Build configuration list for PBXNativeTarget "BackyardBirdsUnitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AF5714432C0D5AEA001E9B8C /* Debug */,
+				AF5714442C0D5AEA001E9B8C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E0A466BE2A153A0E0010173E /* Build configuration list for PBXProject "Backyard Birds" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Backyard Birds.xcodeproj/project.pbxproj
+++ b/Backyard Birds.xcodeproj/project.pbxproj
@@ -1074,10 +1074,11 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds${SAMPLE_CODE_DISAMBIGUATOR}.Widgets";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds.${SAMPLE_CODE_DISAMBIGUATOR}.Widgets";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios.Widgets";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=watchos*]" = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.watch.Widgets";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*]" = "com.example.apple-samplecode.Backyard-Birds$(SAMPLE_CODE_DISAMBIGUATOR).watch.Widgets";
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*]" = "com.example.apple-samplecode.Backyard-Birds.${SAMPLE_CODE_DISAMBIGUATOR}.ios.Widgets";
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=watchos*]" = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios.watch.Widgets";
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*]" = "com.example.apple-samplecode.Backyard-Birds.$(SAMPLE_CODE_DISAMBIGUATOR).ios.watch.Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Backyard-Birds OneMoreThingConf iOS Widgets";
@@ -1126,10 +1127,10 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds${SAMPLE_CODE_DISAMBIGUATOR}.Widgets";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds.${SAMPLE_CODE_DISAMBIGUATOR}.Widgets";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios.Widgets";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=watchos*]" = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.watch.Widgets";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*]" = "com.example.apple-samplecode.Backyard-Birds$(SAMPLE_CODE_DISAMBIGUATOR).watch.Widgets";
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*]" = "com.example.apple-samplecode.Backyard-Birds.$(SAMPLE_CODE_DISAMBIGUATOR).watch.Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Backyard-Birds OneMoreThingConf iOS Widgets";
@@ -1163,14 +1164,14 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.example.apple-samplecode.Backyard-BirdsBITRISEOMTSAMPLE";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.watch";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios.watch";
 				PRODUCT_NAME = "Backyard Birds";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "Backyard-Birds OneMoreThingConf watchOS Developmen";
@@ -1200,14 +1201,14 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.example.apple-samplecode.Backyard-BirdsBITRISEOMTSAMPLE";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.watch";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Backyard-Birds.BITRISEOMTSAMPLE.ios.watch";
 				PRODUCT_NAME = "Backyard Birds";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "Backyard-Birds OneMoreThingConf watchOS Developmen";

--- a/Backyard Birds.xcodeproj/xcshareddata/xcschemes/Backyard Birds (Watch).xcscheme
+++ b/Backyard Birds.xcodeproj/xcshareddata/xcschemes/Backyard Birds (Watch).xcscheme
@@ -64,6 +64,28 @@
                ReferencedContainer = "container:Backyard Birds.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AF57142A2C0D19AB001E9B8C"
+               BuildableName = "Backyard BirdsUITests.xctest"
+               BlueprintName = "Backyard BirdsUITests"
+               ReferencedContainer = "container:Backyard Birds.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AF57143B2C0D5AEA001E9B8C"
+               BuildableName = "BackyardBirdsUnitTests.xctest"
+               BlueprintName = "BackyardBirdsUnitTests"
+               ReferencedContainer = "container:Backyard Birds.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Backyard Birds.xcodeproj/xcshareddata/xcschemes/Backyard Birds.xcscheme
+++ b/Backyard Birds.xcodeproj/xcshareddata/xcschemes/Backyard Birds.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1510"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,7 +27,35 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:UITests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AF57142A2C0D19AB001E9B8C"
+               BuildableName = "Backyard BirdsUITests.xctest"
+               BlueprintName = "Backyard BirdsUITests"
+               ReferencedContainer = "container:Backyard Birds.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AF57143B2C0D5AEA001E9B8C"
+               BuildableName = "BackyardBirdsUnitTests.xctest"
+               BlueprintName = "BackyardBirdsUnitTests"
+               ReferencedContainer = "container:Backyard Birds.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Backyard Birds.xcodeproj/xcshareddata/xcschemes/Widgets (Multiplatform).xcscheme
+++ b/Backyard Birds.xcodeproj/xcshareddata/xcschemes/Widgets (Multiplatform).xcscheme
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1510"
-   version = "2.0"
-   wasCreatedForAppExtension = "YES">
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -43,6 +43,28 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AF57142A2C0D19AB001E9B8C"
+               BuildableName = "Backyard BirdsUITests.xctest"
+               BlueprintName = "Backyard BirdsUITests"
+               ReferencedContainer = "container:Backyard Birds.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AF57143B2C0D5AEA001E9B8C"
+               BuildableName = "BackyardBirdsUnitTests.xctest"
+               BlueprintName = "BackyardBirdsUnitTests"
+               ReferencedContainer = "container:Backyard Birds.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -50,6 +72,7 @@
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
+      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
@@ -90,6 +113,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Backyard BirdsUITests/BackyardsUITests.swift
+++ b/Backyard BirdsUITests/BackyardsUITests.swift
@@ -1,0 +1,66 @@
+//
+//  Backyard_BirdsUITests.swift
+//  Backyard BirdsUITests
+//
+//  Created by Ben Boral on 6/2/24.
+//  Copyright © 2024 Apple. All rights reserved.
+//
+
+import XCTest
+
+final class BackyardsUITests: XCTestCase {
+    
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+        
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testBackyards1() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let elementsQuery = app.scrollViews.otherElements
+        elementsQuery/*@START_MENU_TOKEN@*/.images["Bird 6/FrontWing1"]/*[[".buttons[\"Building 3, Building 1, Floor 2, Plant 1\/Pot, Plant 1\/Variant 1, Plant 5\/Variant 3, Plant 5\/Pot, Plant 3\/Variant 3, Plant 3\/Pot, Plant 4\/Variant 2, Plant 4\/Pot, Plant 4\/Variant 1, Plant 4\/Pot, Plant 5\/Variant 4, Plant 5\/Pot, Fountain\/Terracotta, Bird 6\/BackWing1, Bird 6\/Body, Bird 6\/Belly, Bird 6\/Chin, Bird 6\/Eye, Bird 6\/Beak, Bird 6\/FrontWing1\"].images[\"Bird 6\/FrontWing1\"]",".images[\"Bird 6\/FrontWing1\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery/*@START_MENU_TOKEN@*/.staticTexts["Sunflower Seeds"]/*[[".buttons[\"Bird Food\/Sunflower Seeds, Sunflower Seeds, 6 hr remaining, Choose Food\"].staticTexts[\"Sunflower Seeds\"]",".staticTexts[\"Sunflower Seeds\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery.scrollViews.otherElements/*@START_MENU_TOKEN@*/.staticTexts["Use"]/*[[".buttons[\"Use, 1\"].staticTexts[\"Use\"]",".staticTexts[\"Use\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+    }
+    
+    
+    func testBackyards2() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let elementsQuery = app.scrollViews.otherElements
+        elementsQuery/*@START_MENU_TOKEN@*/.images["Bird 6/FrontWing1"]/*[[".buttons[\"Building 3, Building 1, Floor 2, Plant 1\/Pot, Plant 1\/Variant 1, Plant 5\/Variant 3, Plant 5\/Pot, Plant 3\/Variant 3, Plant 3\/Pot, Plant 4\/Variant 2, Plant 4\/Pot, Plant 4\/Variant 1, Plant 4\/Pot, Plant 5\/Variant 4, Plant 5\/Pot, Fountain\/Terracotta, Bird 6\/BackWing1, Bird 6\/Body, Bird 6\/Belly, Bird 6\/Chin, Bird 6\/Eye, Bird 6\/Beak, Bird 6\/FrontWing1\"].images[\"Bird 6\/FrontWing1\"]",".images[\"Bird 6\/FrontWing1\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery/*@START_MENU_TOKEN@*/.staticTexts["Sunflower Seeds"]/*[[".buttons[\"Bird Food\/Sunflower Seeds, Sunflower Seeds, 6 hr remaining, Choose Food\"].staticTexts[\"Sunflower Seeds\"]",".staticTexts[\"Sunflower Seeds\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery.scrollViews.otherElements/*@START_MENU_TOKEN@*/.staticTexts["Use"]/*[[".buttons[\"Use, 1\"].staticTexts[\"Use\"]",".staticTexts[\"Use\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+    }
+    
+    func testBackyards3() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let elementsQuery = app.scrollViews.otherElements
+        elementsQuery/*@START_MENU_TOKEN@*/.images["Bird 6/FrontWing1"]/*[[".buttons[\"Building 3, Building 1, Floor 2, Plant 1\/Pot, Plant 1\/Variant 1, Plant 5\/Variant 3, Plant 5\/Pot, Plant 3\/Variant 3, Plant 3\/Pot, Plant 4\/Variant 2, Plant 4\/Pot, Plant 4\/Variant 1, Plant 4\/Pot, Plant 5\/Variant 4, Plant 5\/Pot, Fountain\/Terracotta, Bird 6\/BackWing1, Bird 6\/Body, Bird 6\/Belly, Bird 6\/Chin, Bird 6\/Eye, Bird 6\/Beak, Bird 6\/FrontWing1\"].images[\"Bird 6\/FrontWing1\"]",".images[\"Bird 6\/FrontWing1\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery/*@START_MENU_TOKEN@*/.staticTexts["Sunflower Seeds"]/*[[".buttons[\"Bird Food\/Sunflower Seeds, Sunflower Seeds, 6 hr remaining, Choose Food\"].staticTexts[\"Sunflower Seeds\"]",".staticTexts[\"Sunflower Seeds\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery.scrollViews.otherElements/*@START_MENU_TOKEN@*/.staticTexts["Use"]/*[[".buttons[\"Use, 1\"].staticTexts[\"Use\"]",".staticTexts[\"Use\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+    }
+    
+    func testBackyards4() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let elementsQuery = app.scrollViews.otherElements
+        elementsQuery/*@START_MENU_TOKEN@*/.images["Bird 6/FrontWing1"]/*[[".buttons[\"Building 3, Building 1, Floor 2, Plant 1\/Pot, Plant 1\/Variant 1, Plant 5\/Variant 3, Plant 5\/Pot, Plant 3\/Variant 3, Plant 3\/Pot, Plant 4\/Variant 2, Plant 4\/Pot, Plant 4\/Variant 1, Plant 4\/Pot, Plant 5\/Variant 4, Plant 5\/Pot, Fountain\/Terracotta, Bird 6\/BackWing1, Bird 6\/Body, Bird 6\/Belly, Bird 6\/Chin, Bird 6\/Eye, Bird 6\/Beak, Bird 6\/FrontWing1\"].images[\"Bird 6\/FrontWing1\"]",".images[\"Bird 6\/FrontWing1\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery/*@START_MENU_TOKEN@*/.staticTexts["Sunflower Seeds"]/*[[".buttons[\"Bird Food\/Sunflower Seeds, Sunflower Seeds, 6 hr remaining, Choose Food\"].staticTexts[\"Sunflower Seeds\"]",".staticTexts[\"Sunflower Seeds\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        elementsQuery.scrollViews.otherElements/*@START_MENU_TOKEN@*/.staticTexts["Use"]/*[[".buttons[\"Use, 1\"].staticTexts[\"Use\"]",".staticTexts[\"Use\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+    }
+}

--- a/Backyard BirdsUITests/BirdsUITests.swift
+++ b/Backyard BirdsUITests/BirdsUITests.swift
@@ -1,0 +1,72 @@
+//
+//  Backyard_BirdsUITestsLaunchTests.swift
+//  Backyard BirdsUITests
+//
+//  Created by Ben Boral on 6/2/24.
+//  Copyright © 2024 Apple. All rights reserved.
+//
+
+import XCTest
+
+final class BirdsUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testBirds1() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+        
+        let element = app.scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element
+        let bird6Frontwing1Image = element.children(matching: .image).matching(identifier: "Bird 6/FrontWing1").element(boundBy: 0)
+        bird6Frontwing1Image.tap()
+        bird6Frontwing1Image.tap()
+        element.swipeUp()
+        element.swipeUp()
+        element.tap()
+    }
+    
+    func testBirds2() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+        
+        let element = app.scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element
+        let bird6Frontwing1Image = element.children(matching: .image).matching(identifier: "Bird 6/FrontWing1").element(boundBy: 0)
+        bird6Frontwing1Image.tap()
+        bird6Frontwing1Image.tap()
+        element.swipeUp()
+        element.swipeUp()
+        element.tap()
+    }
+    
+    func testBirds3() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+        
+        let element = app.scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element
+        let bird6Frontwing1Image = element.children(matching: .image).matching(identifier: "Bird 6/FrontWing1").element(boundBy: 0)
+        bird6Frontwing1Image.tap()
+        bird6Frontwing1Image.tap()
+        element.swipeUp()
+        element.swipeUp()
+        element.tap()
+    }
+    
+    func testBirds4() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Birds"].tap()
+        
+        let element = app.scrollViews.children(matching: .other).element(boundBy: 0).children(matching: .other).element
+        let bird6Frontwing1Image = element.children(matching: .image).matching(identifier: "Bird 6/FrontWing1").element(boundBy: 0)
+        bird6Frontwing1Image.tap()
+        bird6Frontwing1Image.tap()
+        element.swipeUp()
+        element.swipeUp()
+        element.tap()
+    }
+}

--- a/Backyard BirdsUITests/FailingUITests.swift
+++ b/Backyard BirdsUITests/FailingUITests.swift
@@ -1,0 +1,49 @@
+//
+//  FailingUITests.swift
+//  Backyard BirdsUITests
+//
+//  Created by Ben Boral on 6/2/24.
+//  Copyright © 2024 Apple. All rights reserved.
+//
+
+import XCTest
+
+final class FailingUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testThatFails() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        let scrollViewsQuery = app.scrollViews
+        let elementsQuery = scrollViewsQuery.otherElements
+        
+        let tabBar = app.tabBars["Tab Bar"]
+        tabBar.buttons["Birds"].tap()
+        
+        let element = scrollViewsQuery.children(matching: .other).element(boundBy: 0).children(matching: .other).element
+        element/*@START_MENU_TOKEN@*/.swipeRight()/*[[".swipeUp()",".swipeRight()"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        tabBar.buttons["Plants"].tap()
+        element.children(matching: .staticText).matching(identifier: "Alocasia").element(boundBy: 1).swipeUp()
+        tabBar.buttons["Backyards"].tap()
+        
+        let backyardsNavigationBar = app.navigationBars["Backyards"]
+        backyardsNavigationBar.searchFields["Search"].tap()
+        backyardsNavigationBar.buttons["Cancel"].tap()
+        backyardsNavigationBar.buttons["Cancel"].tap()
+    }
+
+}

--- a/Backyard BirdsUITests/PlantsUITests.swift
+++ b/Backyard BirdsUITests/PlantsUITests.swift
@@ -1,0 +1,76 @@
+//
+//  PlantsUITests.swift
+//  Backyard BirdsUITests
+//
+//  Created by Ben Boral on 6/2/24.
+//  Copyright © 2024 Apple. All rights reserved.
+//
+
+import XCTest
+
+final class PlantsUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testPlants1() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Plants"].tap()
+        let plantsNavigationBar = app.navigationBars["Plants"]
+        let searchSearchField = plantsNavigationBar.searchFields["Search"]
+        searchSearchField.tap()
+        let cancelButton = plantsNavigationBar.buttons["Cancel"]
+        app.collectionViews/*@START_MENU_TOKEN@*/.buttons["Foxglove"]/*[[".cells.buttons[\"Foxglove\"]",".buttons[\"Foxglove\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        cancelButton.tap()
+    }
+    
+    func testPlants2() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Plants"].tap()
+        let plantsNavigationBar = app.navigationBars["Plants"]
+        let searchSearchField = plantsNavigationBar.searchFields["Search"]
+        searchSearchField.tap()
+        let cancelButton = plantsNavigationBar.buttons["Cancel"]
+        app.collectionViews.buttons["Foxglove"].tap()
+        cancelButton.tap()
+    }
+
+    func testPlants3() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Plants"].tap()
+        let plantsNavigationBar = app.navigationBars["Plants"]
+        let searchSearchField = plantsNavigationBar.searchFields["Search"]
+        searchSearchField.tap()
+        let cancelButton = plantsNavigationBar.buttons["Cancel"]
+        app.collectionViews/*@START_MENU_TOKEN@*/.buttons["Foxglove"]/*[[".cells.buttons[\"Foxglove\"]",".buttons[\"Foxglove\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        cancelButton.tap()
+    }
+    
+    func testPlants4() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars["Tab Bar"].buttons["Plants"].tap()
+        let plantsNavigationBar = app.navigationBars["Plants"]
+        let searchSearchField = plantsNavigationBar.searchFields["Search"]
+        searchSearchField.tap()
+        let cancelButton = plantsNavigationBar.buttons["Cancel"]
+        app.collectionViews/*@START_MENU_TOKEN@*/.buttons["Foxglove"]/*[[".cells.buttons[\"Foxglove\"]",".buttons[\"Foxglove\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        cancelButton.tap()
+    }
+
+
+
+}

--- a/BackyardBirdsUnitTests/BackyardBirdsUnitTests.swift
+++ b/BackyardBirdsUnitTests/BackyardBirdsUnitTests.swift
@@ -1,0 +1,259 @@
+//
+//  BackyardBirdsUnitTests.swift
+//  BackyardBirdsUnitTests
+//
+//  Created by Ben Boral on 6/2/24.
+//  Copyright © 2024 Apple. All rights reserved.
+//
+
+import XCTest
+
+final class BackyardBirdsUnitTests: XCTestCase {
+    
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testExample1() {
+        XCTAssertEqual(2 + 2, 4)
+    }
+    
+    func testExample2() {
+        XCTAssertTrue("hello".contains("e"))
+    }
+    
+    func testExample3() {
+        XCTAssertFalse("world".isEmpty)
+    }
+    
+    func testExample4() {
+        XCTAssertNotNil(5)
+    }
+    
+    func testExample5() {
+        XCTAssertNil(nil)
+    }
+    
+    func testExample6() {
+        XCTAssertGreaterThan(10, 5)
+    }
+    
+    func testExample7() {
+        XCTAssertLessThan(3, 8)
+    }
+    
+    func testExample8() {
+        XCTAssert(1 == 1)
+    }
+    
+    func testExample9() {
+        let array = [1, 2, 3]
+        XCTAssertEqual(array.count, 3)
+    }
+    
+    func testExample10() {
+        let dict = ["key": "value"]
+        XCTAssertEqual(dict["key"], "value")
+    }
+    
+    func testExample11() {
+        let str = "hello"
+        XCTAssertEqual(str.uppercased(), "HELLO")
+    }
+    
+    func testExample12() {
+        let set: Set = [1, 2, 3]
+        XCTAssertTrue(set.contains(2))
+    }
+    
+    func testExample13() {
+        let array = [1, 2, 3]
+        XCTAssertEqual(array.first, 1)
+    }
+    
+    func testExample14() {
+        let floatVal: Float = 1.0
+        XCTAssertEqual(floatVal, 1.0, accuracy: 0.0001)
+    }
+    
+    func testExample15() {
+        let doubleVal: Double = 2.0
+        XCTAssertEqual(doubleVal, 2.0, accuracy: 0.0001)
+    }
+    
+    func testExample16() {
+        let str = "hello"
+        XCTAssertFalse(str.isEmpty)
+    }
+    
+    func testExample17() {
+        let num = 5
+        XCTAssertEqual(num % 2, 1)
+    }
+    
+    func testExample18() {
+        let val = true
+        XCTAssertTrue(val)
+    }
+    
+    func testExample19() {
+        let val = false
+        XCTAssertFalse(val)
+    }
+    
+    func testExample20() {
+        let val: Int? = nil
+        XCTAssertNil(val)
+    }
+    
+    func testExample21() {
+        let val: Int? = 5
+        XCTAssertNotNil(val)
+    }
+    
+    func testExample22() {
+        let str = "hello"
+        XCTAssertEqual(String(str.reversed()), "olleh")
+    }
+    
+    func testExample23() {
+        XCTAssertEqual(2*3, 6)
+    }
+    
+    func testExample24() {
+        XCTAssertEqual(9/3, 3)
+    }
+    
+    func testExample25() {
+        let array = [1, 2, 3, 4, 5]
+        XCTAssertTrue(array.contains(4))
+    }
+    
+    func testExample26() {
+        XCTAssertGreaterThanOrEqual(5, 5)
+    }
+    
+    func testExample27() {
+        let num = 10
+        XCTAssertLessThanOrEqual(num, 12)
+    }
+    
+    func testExample28() {
+        let str = "Bitrise"
+        XCTAssertEqual(str.prefix(3), "Bit")
+    }
+    
+    func testExample29() {
+        let str = "Swift"
+        XCTAssertEqual(str.suffix(3), "ift")
+    }
+    
+    func testExample30() {
+        let array = [1, 2, 3]
+        XCTAssertEqual(array.last, 3)
+    }
+    
+    func testExample31() {
+        let dict = ["a": 1, "b": 2]
+        XCTAssertEqual(dict.keys.count, 2)
+    }
+    
+    func testExample32() {
+        let dict = ["a": 1, "b": 2]
+        XCTAssertEqual(dict.values.count, 2)
+    }
+    
+    func testExample33() {
+        let dict = ["a": 1, "b": 2]
+        XCTAssertTrue(dict.keys.contains("a"))
+    }
+    
+    func testExample34() {
+        let str = "apple"
+        XCTAssertEqual(str.capitalized, "Apple")
+    }
+    
+    func testExample35() {
+        let array = [1, 2, 3]
+        XCTAssertEqual(array.map { $0 * 2 }, [2, 4, 6])
+    }
+    
+    func testExample36() {
+        let array = [1, 2, 3]
+        XCTAssertEqual(array.filter { $0 > 1 }, [2, 3])
+    }
+    
+    func testExample37() {
+        let str = "   hello   "
+        XCTAssertEqual(str.trimmingCharacters(in: .whitespaces), "hello")
+    }
+    
+    func testExample38() {
+        let array = [1, 2, 3]
+        XCTAssertEqual(array.reduce(0, +), 6)
+    }
+    
+    func testExample39() {
+        let str = "swift"
+        XCTAssertEqual(str.count, 5)
+    }
+    
+    func testExample40() {
+        let boolVal = true
+        XCTAssertTrue(boolVal)
+    }
+    
+    func testExample41() {
+        let boolVal = false
+        XCTAssertFalse(boolVal)
+    }
+    
+    func testExample42() {
+        let str = "hello"
+        XCTAssertEqual(str.first, "h")
+    }
+    
+    func testExample43() {
+        let str = "swift"
+        XCTAssertEqual(str.last, "t")
+    }
+    
+    func testExample44() {
+        let str = "hello"
+        XCTAssertEqual(str.dropFirst(), "ello")
+    }
+    
+    func testExample45() {
+        let str = "swift"
+        XCTAssertEqual(str.dropLast(), "swif")
+    }
+    
+    func testExample46() {
+        let array = [1, 2, 3]
+        XCTAssertEqual(array.first(where: { $0 > 1 }), 2)
+    }
+    
+    func testExample47() {
+        let dict = ["a": 1, "b": 2]
+        XCTAssertEqual(dict["a"], 1)
+    }
+    
+    func testExample48() {
+        let str = "hello, world"
+        XCTAssertEqual(str.split(separator: ",").count, 2)
+    }
+    
+    func testExample49() {
+        let str = "hello"
+        XCTAssertEqual(str.indices.count, 5)
+    }
+    
+    func testExample50() {
+        let str = "hello"
+        XCTAssertEqual(str.index(after: str.startIndex), str.index(str.startIndex, offsetBy: 1))
+    }
+}

--- a/FailingTests.xctestplan
+++ b/FailingTests.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "86324A9C-06E9-48D7-B2D9-EBBBAB96DADB",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "BackyardsUITests",
+        "BirdsUITests",
+        "FailingUITests"
+      ],
+      "target" : {
+        "containerPath" : "container:Backyard Birds.xcodeproj",
+        "identifier" : "AF57142A2C0D19AB001E9B8C",
+        "name" : "Backyard BirdsUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -1,0 +1,33 @@
+{
+  "configurations" : [
+    {
+      "id" : "DC05062F-5170-46FD-B952-C58A8BF1190D",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Backyard Birds.xcodeproj",
+      "identifier" : "E0A466C22A153A0E0010173E",
+      "name" : "Backyard Birds"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "skippedTests" : [
+        "PlantsUITests"
+      ],
+      "target" : {
+        "containerPath" : "container:Backyard Birds.xcodeproj",
+        "identifier" : "AF57142A2C0D19AB001E9B8C",
+        "name" : "Backyard BirdsUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "56ADF3B3-E317-418F-8685-941592AB73DA",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Backyard Birds.xcodeproj",
+        "identifier" : "AF57143B2C0D5AEA001E9B8C",
+        "name" : "BackyardBirdsUnitTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
First time XCUITest recorder has ever been useful!!!

This adds multiple classes of UI tests. I added multiple classes because my recollection is that when using simulator clones, XCTest splits them up at the class level.

I added a failing UI test so we can see the nice video in the html xcode test report

Also included unit tests.

There are three test plans:
* UITests
* UnitTests
* FailingTests

This will accommodate a pipeline with a single build-for-testing workflow in stage 1 and then in stage 2, parallel workflows using test-without-building
