### PR TITLE
run tests serially in random order

### DIFF
--- a/FailingTests.xctestplan
+++ b/FailingTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "testExecutionOrdering" : "random",
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [

--- a/UITests.xctestplan
+++ b/UITests.xctestplan
@@ -14,11 +14,11 @@
       "containerPath" : "container:Backyard Birds.xcodeproj",
       "identifier" : "E0A466C22A153A0E0010173E",
       "name" : "Backyard Birds"
-    }
+    },
+    "testExecutionOrdering" : "random"
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
       "skippedTests" : [
         "PlantsUITests"
       ],

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "testExecutionOrdering" : "random",
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [


### PR DESCRIPTION
so that we can override this setting for the future